### PR TITLE
Removes windows as the defalut for installation

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -49,7 +49,6 @@
                 "sha256:05eed71e2e327246ad6b38c540c4a3117230b19679b875190486ddd2d721422d",
                 "sha256:f8ac84de7840f5b9c4e3347b3c1eaa50f7e49c2b07596221daec5edaabbd7c48"
             ],
-            "markers": "sys_platform == 'win32'",
             "version": "==0.4.1"
         },
         "django": {


### PR DESCRIPTION
Some packages have been marked to windows system while creating the piplock file. Removing the "win32" tag.